### PR TITLE
Allow file size upload of 100M (instead of 1M) in reverse proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,9 @@ http {
         # Set the default index file for the server
         index index.html;
 
+        # Set the maximum file size for uploads
+        client_max_body_size 100M;
+
         # Serve Angular UI
         location / {
             try_files $uri $uri/ /index.html;  # Fallback to index.html for Angular routing


### PR DESCRIPTION
This change allows for uploading books up to 100MB. 

Currently the backend defines a 100MB limit in the [FileUploadService.java](https://github.com/adityachandelgit/BookLore/blob/master/booklore-api/src/main/java/com/adityachandel/booklore/service/FileUploadService.java). However nginx has a default upload limit of 1MB. This pull requests sets a 100MB upload limit for nginx.