### PR TITLE
feat: allow modifying mariadb connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
-      - MYSQL_ROOT_PASSWORD=your_secure_password # Use a strong password; must match the one in the mariadb service
+      - DATABASE_URL=jdbc:mariadb://mariadb:3306/booklore
+      - DATABASE_USERNAME=booklore
+      - DATABASE_PASSWORD=your_secure_password # Use a strong password; must match the one in the mariadb service
     depends_on:
       mariadb:
         condition: service_healthy
@@ -66,7 +68,10 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
-      - MYSQL_ROOT_PASSWORD=your_secure_password # Use a strong password; must match the one in the booklore service
+      - MYSQL_ROOT_PASSWORD=your_secure_password # Use a strong password
+      - MYSQL_DATABASE=booklore
+      - MYSQL_USER=booklore
+      - MYSQL_PASSWORD=your_secure_password # Use a strong password; must match the one in the booklore service
     volumes:
       - /your/local/path/to/mariadb/config:/config
     restart: unless-stopped
@@ -106,6 +111,19 @@ Password: admin123
 ```
 > ⚠️ **Important:**  
 > You’ll be prompted to change the default password upon your first login to ensure better security.
+
+## Configuration
+
+The following environment variables can be configured:
+
+| Variable Name     | Description               | Default Value                                                       |
+|-------------------|---------------------------|---------------------------------------------------------------------|
+| DATABASE_URL      | JDBC connection URL       | `jdbc:mariadb://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}` |
+| DATABASE_HOST     | Database hostname         | `mariadb`                                                           |
+| DATABASE_PORT     | Database port             | `3306`                                                              |
+| DATABASE_NAME     | Database name             | `booklore`                                                          |
+| DATABASE_USERNAME | Database username for app | `root`                                                              |
+| DATABASE_PASSWORD | Database password for app | **required**                                                        |
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
-      - DATABASE_URL=jdbc:mariadb://mariadb:3306/booklore
-      - DATABASE_USERNAME=booklore
-      - DATABASE_PASSWORD=your_secure_password # Use a strong password; must match the one in the mariadb service
+      - DATABASE_URL=jdbc:mariadb://mariadb:3306/booklore # Only modify this if you're familiar with JDBC and your database setup
+      - DATABASE_USERNAME=booklore # Must match MYSQL_USER defined in the mariadb container
+      - DATABASE_PASSWORD=your_secure_password # Use a strong password; must match MYSQL_PASSWORD defined in the mariadb container 
     depends_on:
       mariadb:
         condition: service_healthy
@@ -68,10 +68,10 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
-      - MYSQL_ROOT_PASSWORD=your_secure_password # Use a strong password
+      - MYSQL_ROOT_PASSWORD=super_secure_password # Use a strong password for the database's root user, should be different from MYSQL_PASSWORD
       - MYSQL_DATABASE=booklore
-      - MYSQL_USER=booklore
-      - MYSQL_PASSWORD=your_secure_password # Use a strong password; must match the one in the booklore service
+      - MYSQL_USER=booklore # Must match DATABASE_USERNAME defined in the booklore container
+      - MYSQL_PASSWORD=your_secure_password # Use a strong password; must match DATABASE_PASSWORD defined in the booklore container
     volumes:
       - /your/local/path/to/mariadb/config:/config
     restart: unless-stopped

--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -14,12 +14,10 @@ spring:
   application:
     name: booklore-api
   datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://${DB_HOST:mariadb}:3306/booklore?createDatabaseIfNotExist=true
-    username: root
-    password: ${MYSQL_ROOT_PASSWORD}
+    url: ${DATABASE_URL:jdbc:mariadb://${DATABASE_HOST:${DB_HOST:mariadb}}:${DATABASE_PORT:3306}/${DATABASE_NAME:booklore}?createDatabaseIfNotExist=true}
+    username: ${DATABASE_USERNAME:root}
+    password: ${DATABASE_PASSWORD:${MYSQL_ROOT_PASSWORD}}
   jpa:
-    database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/example-docker/.env
+++ b/example-docker/.env
@@ -12,7 +12,7 @@ TZ=Etc/UTC     # Change this to your timezone (e.g., America/New_York, Asia/Kolk
 
 # Database Credentials (Replace with a secure password)
 # This password is used by MariaDB. Make sure to keep it secure.
-MYSQL_ROOT_PASSWORD=your_secure_password
+MYSQL_ROOT_PASSWORD=super_secure_password
 MYSQL_DATABASE=booklore
 MYSQL_USER=booklore
 MYSQL_PASSWORD=your_secure_password

--- a/example-docker/.env
+++ b/example-docker/.env
@@ -13,6 +13,9 @@ TZ=Etc/UTC     # Change this to your timezone (e.g., America/New_York, Asia/Kolk
 # Database Credentials (Replace with a secure password)
 # This password is used by MariaDB. Make sure to keep it secure.
 MYSQL_ROOT_PASSWORD=your_secure_password
+MYSQL_DATABASE=booklore
+MYSQL_USER=booklore
+MYSQL_PASSWORD=your_secure_password
 
 # Paths for Docker Volumes (Update these paths as per your system)
 # These paths store persistent data for Booklore and MariaDB.

--- a/example-docker/docker-compose.yml
+++ b/example-docker/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     container_name: booklore_server
     env_file:
       - .env
+    environment:
+      - DATABASE_URL=jdbc:mariadb://mariadb:3306/${MYSQL_DATABASE}
+      - DATABASE_USERNAME=${MYSQL_USER}
+      - DATABASE_PASSWORD=${MYSQL_PASSWORD}
     depends_on:
       mariadb:
         condition: service_healthy
@@ -15,7 +19,7 @@ services:
       - ${BOOKLORE_BOOKS_PATH}:/books
 
   mariadb:
-    image: lscr.io/linuxserver/mariadb:11.4.5
+    image: lscr.io/linuxserver/mariadb:11.4
     container_name: booklore_mariadb
     env_file:
       - .env


### PR DESCRIPTION
With these changes, we will be able to modify host, port, database name (as well as the whole url), username and password individually.

This is required for the following scenarios (and more):
- using a shared database for multiple services (with a separate username)
- separate root and per-application account, giving an app root permission is not a recommended approach
- port forwarding from e.g. homelab to localhost (e.g. for debugging)
- use MySQL instead of MariaDB (for whatever reason)

Also, this PR:
- removes deprecation warning (Hibernate now automatically detects dialect)
- keeps backwards compatibility using `DB_HOST` and `MYSQL_ROOT_PASSWORD` variable