### PR TITLE
fix: uploading books on Windows (dev env) doesn't work

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/config/AppProperties.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/config/AppProperties.java
@@ -10,6 +10,5 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 public class AppProperties {
-    private String pathBook;
     private String pathConfig;
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/FileUploadService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/FileUploadService.java
@@ -55,14 +55,14 @@ public class FileUploadService {
         }
 
         try {
-            file.transferTo(storageFile);
+            file.transferTo(storagePath); // storagePath here is required for windows, otherwise it will be resoled relative to Tomcat FS
             log.info("File uploaded successfully: {}", storageFile.getAbsolutePath());
             Book book = processFile(file, libraryEntity, libraryPathEntity, storageFile);
             notificationService.sendMessage(Topic.BOOK_ADD, book);
             log.info("Book processed successfully: {}", book.getMetadata().getTitle());
             return book;
         } catch (IOException e) {
-            log.error("Error saving file: {}", e.getMessage());
+            log.error("Error saving file", e);
             throw ApiError.FILE_READ_ERROR.createException(e.getMessage());
         }
     }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/FileProcessingUtils.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/FileProcessingUtils.java
@@ -1,9 +1,8 @@
 package com.adityachandel.booklore.service.fileprocessor;
 
-import com.adityachandel.booklore.config.AppProperties;
 import com.adityachandel.booklore.model.entity.BookMetadataEntity;
-import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.service.AppSettingService;
+import com.adityachandel.booklore.util.FileService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,24 +25,22 @@ import java.util.stream.Stream;
 @Slf4j
 public class FileProcessingUtils {
 
-    private final AppProperties appProperties;
+    private final FileService fileService;
     private final AppSettingService appSettingService;
 
     public void setBookCoverPath(long bookId, BookMetadataEntity bookMetadataEntity) {
-        bookMetadataEntity.setThumbnail(appProperties.getPathConfig() + "/thumbs/" + bookId + "/f.jpg");
+        bookMetadataEntity.setThumbnail(fileService.getThumbnailPath(bookId) + "/f.jpg");
         bookMetadataEntity.setCoverUpdatedOn(Instant.now());
     }
 
     public boolean saveCoverImage(BufferedImage coverImage, long bookId) throws IOException {
-        File coverDirectory = new File(appProperties.getPathConfig() + "/thumbs");
-
         String resolution = appSettingService.getAppSettings().getCoverSettings().getResolution();
         String[] split = resolution.split("x");
         int x = Integer.parseInt(split[0]);
         int y = Integer.parseInt(split[1]);
 
         BufferedImage resizedImage = resizeImage(coverImage, x, y);
-        File bookDirectory = new File(coverDirectory, String.valueOf(bookId));
+        File bookDirectory = new File(fileService.getThumbnailPath(bookId));
         if (!bookDirectory.exists()) {
             if (!bookDirectory.mkdirs()) {
                 throw new IOException("Failed to create directory: " + bookDirectory.getAbsolutePath());
@@ -65,7 +62,7 @@ public class FileProcessingUtils {
 
     public void deleteBookCovers(Set<Long> bookIds) {
         for (Long bookId : bookIds) {
-            String bookCoverFolder = appProperties.getPathConfig() + "/thumbs/" + bookId;
+            String bookCoverFolder = fileService.getThumbnailPath(bookId);
             Path folderPath = Paths.get(bookCoverFolder);
             try {
                 if (Files.exists(folderPath) && Files.isDirectory(folderPath)) {

--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -1,5 +1,4 @@
 app:
-  path-book: '/app/books'
   path-config: '/app/data'
 
 spring:


### PR DESCRIPTION
While trying to setup a dev environment on my main PC (Windows), I met with an error.

The error comes from Tomcat or even JDK implementation, because they handle `transferTo(File)` and `transferTo(Path)` differently. In the project, you use the Path more often and resolve its child (e.g. in `PathService`). But here in `FileUploadService`, `transferTo(File)` was used.

Some examples:
`storagePath` is equal to: \forks\BookLore\local\booktitle.epub
`storageFile` is equal to the same, but on `transferTo(storageFile)`, I received

```logs
2025-04-19T17:43:20.998+02:00 ERROR 36180 --- [booklore-api] [nio-8080-exec-6] c.a.booklore.service.FileUploadService   : Error saving file

java.io.IOException: java.io.FileNotFoundException: C:\Users\astappiev\AppData\Local\Temp\tomcat.8080.6568768355172360310\work\Tomcat\localhost\ROOT\forks\BookLore\local\booktitle.epub (The system cannot find the path specified)
	at org.apache.catalina.core.ApplicationPart.write(ApplicationPart.java:119) ~[tomcat-embed-core-10.1.36.jar:10.1.36]
	at org.springframework.web.multipart.support.StandardMultipartHttpServletRequest$StandardMultipartFile.transferTo(StandardMultipartHttpServletRequest.java:269) ~[spring-web-6.2.3.jar:6.2.3]
	at com.adityachandel.booklore.service.FileUploadService.uploadFile(FileUploadService.java:58) ~[main/:na]
	at com.adityachandel.booklore.controller.FileUploadController.uploadFile(FileUploadController.java:27) ~[main/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359) ~[spring-aop-6.2.3.jar:6.2.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196) ~[spring-aop-6.2.3.jar:6.2.3]
```

Where we can see the path of the file was resolved to `C:\Users\astappiev\AppData\Local\Temp\tomcat.8080.6568768355172360310\work\Tomcat\localhost\ROOT\forks\BookLore\local\booktitle.epub`.

Replacing it with `transferTo(storagePath)` fixes the error, and my files upload without any errors.

I'm not sure if there are any performance with difference between these two methods, it seems like `transferTo(Path)` reads the file into buffer and writes into another OutputFileStream, while `transferTo(File)` is doing something else, the implementation is hidden in the JDK, so probably it was more performant as implemented low level. However, I consider this difference such that it can be neglected.

Also in this PR:
- remove `pathBook`, as it's not used and probably obsolete because now it's per library.
- refactor `FileProcessingUtils` to use `fileService.getThumbnailPath` to make it consistent and more error resistant