### PR TITLE
feat: add Remote-User auth (alt names ForwardAuth, Trusted Header SSO)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,25 +10,22 @@ COPY ./booklore-ui /angular-app/
 RUN npm run build --configuration=production
 
 # Stage 2: Build the Spring Boot app with Gradle
-FROM gradle:jdk21-alpine AS springboot-build
+FROM gradle:8-jdk21-alpine AS springboot-build
 
 WORKDIR /springboot-app
 
-COPY ./booklore-api/gradlew ./booklore-api/gradle/ /springboot-app/
 COPY ./booklore-api/build.gradle ./booklore-api/settings.gradle /springboot-app/
-COPY ./booklore-api/gradle /springboot-app/gradle
 COPY ./booklore-api/src /springboot-app/src
-COPY ./booklore-api/src/main/resources/application.yaml /springboot-app/src/main/resources/application.yaml
 
 # Inject version into application.yaml using yq
 ARG APP_VERSION
 RUN apk add --no-cache yq && \
     yq eval '.app.version = strenv(APP_VERSION)' -i /springboot-app/src/main/resources/application.yaml
 
-RUN ./gradlew clean build
+RUN gradle clean build
 
 # Stage 3: Final image
-FROM eclipse-temurin:21.0.5_11-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 RUN apk update && apk add nginx
 

--- a/README.md
+++ b/README.md
@@ -120,14 +120,36 @@ Password: admin123
 
 The following environment variables can be configured:
 
-| Variable Name     | Description               | Default Value                                                       |
-|-------------------|---------------------------|---------------------------------------------------------------------|
-| DATABASE_URL      | JDBC connection URL       | `jdbc:mariadb://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}` |
-| DATABASE_HOST     | Database hostname         | `mariadb`                                                           |
-| DATABASE_PORT     | Database port             | `3306`                                                              |
-| DATABASE_NAME     | Database name             | `booklore`                                                          |
-| DATABASE_USERNAME | Database username for app | `root`                                                              |
-| DATABASE_PASSWORD | Database password for app | **required**                                                        |
+| Variable Name                | Description                             | Default Value                                                       |
+|------------------------------|-----------------------------------------|---------------------------------------------------------------------|
+| DATABASE_URL                 | JDBC connection URL                     | `jdbc:mariadb://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}` |
+| DATABASE_HOST                | Database hostname                       | `mariadb`                                                           |
+| DATABASE_PORT                | Database port                           | `3306`                                                              |
+| DATABASE_NAME                | Database name                           | `booklore`                                                          |
+| DATABASE_USERNAME            | Database username for app               | `root`                                                              |
+| DATABASE_PASSWORD            | Database password for app               | **required**                                                        |
+| REMOTE_AUTH_ENABLED          | Enable remote authentication            | `false`                                                             |
+| REMOTE_AUTH_CREATE_NEW_USERS | Auto-create users from remote auth      | `true`                                                              |
+| REMOTE_AUTH_HEADER_NAME      | HTTP header containing user's name      | `Remote-Name`                                                       |
+| REMOTE_AUTH_HEADER_USER      | HTTP header containing username         | `Remote-User`                                                       |
+| REMOTE_AUTH_HEADER_EMAIL     | HTTP header containing user's email     | `Remote-Email`                                                      |
+| REMOTE_AUTH_HEADER_GROUPS    | HTTP header containing user's groups    | `Remote-Groups`                                                     |
+| REMOTE_AUTH_ADMIN_GROUP      | Group name that grants admin privileges | -                                                                   |
+| LOG_LEVEL                    | Log level for the application           | `INFO`                                                              |
+| ROOT_LOG_LEVEL               | If you want to see all Spring logs      | `INFO`                                                              |
+
+### Remote Authentication (Trusted Header SSO, Forward Auth)
+
+If you run BookLore behind a reverse proxy with remote authentication (middleware),
+you can enable automatic login by setting `REMOTE_AUTH_ENABLED` to `true`.
+
+This allows you to use your existing authentication system (e.g., OAuth, SAML) to log in to BookLore.
+
+Example implementations:
+- https://www.authelia.com/integration/trusted-header-sso/introduction/
+- https://caddyserver.com/docs/caddyfile/directives/forward_auth
+- https://doc.traefik.io/traefik/middlewares/http/forwardauth/
+- https://github.com/sevensolutions/traefik-oidc-auth (Traefik OIDC Auth)
 
 ## 🤝 Community & Support
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/config/AppProperties.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/config/AppProperties.java
@@ -11,4 +11,19 @@ import org.springframework.stereotype.Component;
 @Setter
 public class AppProperties {
     private String pathConfig;
+    private String version;
+
+    private RemoteAuth remoteAuth;
+
+    @Getter
+    @Setter
+    public static class RemoteAuth {
+        private boolean enabled;
+        private boolean createNewUsers;
+        private String headerName;
+        private String headerUser;
+        private String headerEmail;
+        private String headerGroups;
+        private String adminGroup;
+    }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/config/security/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
+                        .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/remote").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/api/v1/books/*/cover").permitAll()
                         .requestMatchers(

--- a/booklore-api/src/main/java/com/adityachandel/booklore/controller/AuthenticationController.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/controller/AuthenticationController.java
@@ -1,26 +1,29 @@
 package com.adityachandel.booklore.controller;
 
+import com.adityachandel.booklore.config.AppProperties;
 import com.adityachandel.booklore.config.security.AuthenticationService;
+import com.adityachandel.booklore.exception.ApiError;
 import com.adityachandel.booklore.model.dto.UserCreateRequest;
 import com.adityachandel.booklore.model.dto.request.RefreshTokenRequest;
 import com.adityachandel.booklore.model.dto.request.UserLoginRequest;
 import com.adityachandel.booklore.service.user.UserCreatorService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Locale;
 import java.util.Map;
 
+@Slf4j
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthenticationController {
 
+    private final AppProperties appProperties;
     private final UserCreatorService userCreatorService;
     private final AuthenticationService authenticationService;
 
@@ -39,5 +42,21 @@ public class AuthenticationController {
     @PostMapping("/refresh")
     public ResponseEntity<Map<String, String>> refreshToken(@Valid @RequestBody RefreshTokenRequest request) {
         return authenticationService.refreshToken(request.getRefreshToken());
+    }
+
+    @GetMapping("/remote")
+    public ResponseEntity<Map<String, String>> loginRemote(@RequestHeader Map<String, String> headers) {
+        if (!appProperties.getRemoteAuth().isEnabled()) {
+            throw ApiError.REMOTE_AUTH_DISABLED.createException();
+        }
+
+        String name = headers.get(appProperties.getRemoteAuth().getHeaderName().toLowerCase(Locale.ROOT));
+        String username = headers.get(appProperties.getRemoteAuth().getHeaderUser().toLowerCase(Locale.ROOT));
+        String email = headers.get(appProperties.getRemoteAuth().getHeaderEmail().toLowerCase(Locale.ROOT));
+        String groups = headers.get(appProperties.getRemoteAuth().getHeaderGroups().toLowerCase(Locale.ROOT));
+        log.debug("Remote-Auth: retrieved values from headers: name: {}, username: {}, email: {}, groups: {}", name, username, email, groups);
+        log.debug("Remote-Auth: remote auth settings: {}", appProperties.getRemoteAuth());
+
+        return authenticationService.loginRemote(name, username, email, groups);
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/exception/ApiError.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/exception/ApiError.java
@@ -39,7 +39,8 @@ public enum ApiError {
     PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "Incorrect current password"),
     PASSWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "Password must be at least 6 characters long"),
     PASSWORD_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "New password cannot be the same as the current password"),
-    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "Invalid credentials");
+    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "Invalid credentials"),
+    REMOTE_AUTH_DISABLED(HttpStatus.NON_AUTHORITATIVE_INFORMATION, "Remote login is disabled");
 
     private final HttpStatus status;
     private final String message;

--- a/booklore-api/src/main/resources/application.yaml
+++ b/booklore-api/src/main/resources/application.yaml
@@ -2,6 +2,15 @@ app:
   path-config: '/app/data'
   version: 'v0.0.40'
 
+  remote-auth:
+    enabled: ${REMOTE_AUTH_ENABLED:false}
+    create-new-users: ${REMOTE_AUTH_CREATE_NEW_USERS:true}
+    header-name: ${REMOTE_AUTH_HEADER_NAME:Remote-Name}
+    header-user: ${REMOTE_AUTH_HEADER_USER:Remote-User}
+    header-email: ${REMOTE_AUTH_HEADER_EMAIL:Remote-Email}
+    header-groups: ${REMOTE_AUTH_HEADER_GROUPS:Remote-Groups}
+    admin-group: ${REMOTE_AUTH_ADMIN_GROUP}
+
 spring:
   servlet:
     multipart:
@@ -34,6 +43,7 @@ spring:
 
 logging:
   level:
-    root: INFO
+    root: ${ROOT_LOG_LEVEL:INFO}
+    com.adityachandel.booklore: ${LOG_LEVEL:INFO}
     org.apache.fontbox: ERROR
     org.apache.pdfbox: ERROR

--- a/booklore-ui/src/app/core/component/login/login.component.ts
+++ b/booklore-ui/src/app/core/component/login/login.component.ts
@@ -31,6 +31,11 @@ export class LoginComponent {
   errorMessage = '';
 
   constructor(private authService: AuthService, private router: Router) {
+    this.authService.remoteLogin().subscribe({
+      next: () => {
+        this.router.navigate(['/dashboard']);
+      },
+    });
   }
 
   login(): void {

--- a/booklore-ui/src/app/core/service/auth.service.ts
+++ b/booklore-ui/src/app/core/service/auth.service.ts
@@ -26,6 +26,17 @@ export class AuthService {
     );
   }
 
+  remoteLogin(): Observable<any> {
+    return this.http.get<{ accessToken: string; refreshToken: string }>(`${this.apiUrl}/remote`).pipe(
+      tap((response) => {
+        if (response.accessToken && response.refreshToken) {
+          this.saveTokens(response.accessToken, response.refreshToken);
+          this.getRxStompService().activate();
+        }
+      })
+    );
+  }
+
   refreshToken(): Observable<{ accessToken: string; refreshToken: string }> {
     const refreshToken = this.getRefreshToken();
     return this.http.post<{ accessToken: string; refreshToken: string }>(`${this.apiUrl}/refresh`, {refreshToken}).pipe(


### PR DESCRIPTION
I have started an attempt to implemented OIDC, as I previously raised in https://github.com/adityachandelgit/BookLore/issues/77.
But was unable to make both, OIDC and simple username/password auths work together.

Therefore, today I decided to abandon the idea and implement MVP solution.

In this PR, I'm suggesting adding a Remote-User auth (requires booklore is running behind a reverse proxy).

This will work with the following setups:
https://doc.traefik.io/traefik/middlewares/http/forwardauth/
https://caddyserver.com/docs/caddyfile/directives/forward_auth
https://www.authelia.com/integration/trusted-header-sso/introduction/

What do you think?