### PR TITLE
Add infinite scroll on epub reader in mobile view

### DIFF
--- a/booklore-ui/src/app/book/components/epub-viewer/component/epub-viewer.component.html
+++ b/booklore-ui/src/app/book/components/epub-viewer/component/epub-viewer.component.html
@@ -42,7 +42,7 @@
 
     <div id="epubContainer" #epubContainer></div>
 
-    <button class="epub-controls-left" (click)="prevPage()">←</button>
-    <button class="epub-controls-right" (click)="nextPage()">→</button>
+    <button *ngIf="!isMobile" class="epub-controls-left" (click)="prevPage()">←</button>
+    <button *ngIf="!isMobile" class="epub-controls-right" (click)="nextPage()">→</button>
   </div>
 </div>

--- a/booklore-ui/src/app/book/components/epub-viewer/component/epub-viewer.component.ts
+++ b/booklore-ui/src/app/book/components/epub-viewer/component/epub-viewer.component.ts
@@ -60,6 +60,7 @@ export class EpubViewerComponent implements OnInit, OnDestroy {
   currentChapter = '';
   isDrawerVisible = false;
   isSettingsDrawerVisible = false;
+  isMobile = false; 
   private book: any;
   private rendition: any;
   private keyListener: (e: KeyboardEvent) => void = () => {
@@ -114,6 +115,8 @@ export class EpubViewerComponent implements OnInit, OnDestroy {
           fileReader.onload = () => {
             this.book = ePub(fileReader.result as ArrayBuffer);
 
+            this.isMobile = window.innerWidth <= 768;
+
             this.book.loaded.navigation.then((nav: any) => {
               this.chapters = nav.toc.map((chapter: any) => ({
                 label: chapter.label,
@@ -122,7 +125,8 @@ export class EpubViewerComponent implements OnInit, OnDestroy {
             });
 
             this.rendition = this.book.renderTo(this.epubContainer.nativeElement, {
-              flow: 'paginated',
+              flow: this.isMobile ? 'scrolled' : 'paginated',
+              manager: this.isMobile ? 'continuous' : 'default',
               width: '100%',
               height: '100%',
               allowScriptedContent: true,


### PR DESCRIPTION
Add infinite scroll on the epub reader in the mobile view so that its easier to read.

Before:
![Screenshot From 2025-05-17 15-46-11](https://github.com/user-attachments/assets/ff2c5aea-0a08-4335-bd15-7ae29cd84414)

The next page arrow interferes with the content on the page

Now: 
![Screenshot From 2025-05-17 15-47-40](https://github.com/user-attachments/assets/91053c77-910a-4242-9a2b-15cc60b9c98e)

smooth scrolling across the book.