### PR TITLE
fix: library update errors on invalid categories

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/BookCreatorService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/BookCreatorService.java
@@ -45,13 +45,15 @@ public class BookCreatorService {
 
     public void addCategoriesToBook(List<String> categories, BookEntity bookEntity) {
         for (String category : categories) {
-            Optional<CategoryEntity> catOpt = categoryRepository.findByName(category);
+            // Truncate category name to fit in VARCHAR(255)
+            String truncatedCategory = truncate(category, 255);
+            Optional<CategoryEntity> catOpt = categoryRepository.findByName(truncatedCategory);
             CategoryEntity categoryEntity;
             if (catOpt.isPresent()) {
                 categoryEntity = catOpt.get();
             } else {
                 categoryEntity = CategoryEntity.builder()
-                        .name(category)
+                        .name(truncatedCategory)
                         .build();
                 categoryEntity = categoryRepository.save(categoryEntity);
             }
@@ -79,6 +81,17 @@ public class BookCreatorService {
             }
             bookEntity.getMetadata().getAuthors().add(authorEntity);
         }
+    }
+    
+    /**
+     * Truncates a string to the specified maximum length
+     * @param input The input string
+     * @param maxLength The maximum length
+     * @return The truncated string, or null if input is null
+     */
+    private String truncate(String input, int maxLength) {
+        if (input == null) return null;
+        return input.length() <= maxLength ? input : input.substring(0, maxLength);
     }
 
     public void saveConnections(BookEntity bookEntity) {


### PR DESCRIPTION
Fixes adityachandelgit/BookLore#345

- Truncate category names to fit within a VARCHAR(255) limit
- Skip subjects that are null, empty, too long, or contain newlines/whitespace

