### PR TITLE
fix: allow book viewers while Remote Auth enabled

### DIFF
--- a/booklore-ui/src/app/auth-initializer.ts
+++ b/booklore-ui/src/app/auth-initializer.ts
@@ -55,7 +55,6 @@ export function initializeAuthFactory() {
           } else if (settings.remoteAuthEnabled) {
             authService.remoteLogin().subscribe({
               next: () => {
-                router.navigate(['/dashboard']);
                 resolve();
               },
               error: resolve


### PR DESCRIPTION
Fixes adityachandelgit/BookLore#384

- Small change to remove the router navigation to '/dashboard'. When a new window is created to launch the book viewer this is called and just navigates away.