### PR TITLE
feat(book-browser): enable shift-click multi-selection and "Select Al…

### DIFF
--- a/booklore-ui/src/app/book/components/book-browser/book-browser.component.html
+++ b/booklore-ui/src/app/book/components/book-browser/book-browser.component.html
@@ -193,15 +193,17 @@
                     class="grid"
                     #container
                     [ngStyle]="{'grid-template-columns': 'repeat(auto-fill, minmax(' + gridColumnMinWidth + ', 1fr))'}">
-                    @for (book of scroll.viewPortItems; track book) {
+                    @for (book of scroll.viewPortItems; let i = $index; track book) {
                       <div
                         class="virtual-scroller-item relative"
                         [ngStyle]="{width: currentCardSize.width + 'px', height: currentCardSize.height + 'px'}">
                         <app-book-card
+                          [index]="i"
                           [book]="book"
                           [isCheckboxEnabled]="true"
                           [onBookSelect]="handleBookSelect.bind(this)"
                           [isSeriesCollapsed]="seriesCollapseFilter.isSeriesCollapsed"
+                          (checkboxClick)="onCheckboxClicked($event)"
                           [isSelected]="selectedBooks.has(book.id)">
                         </app-book-card>
                       </div>
@@ -220,7 +222,7 @@
                       <p-tieredmenu #menu [model]="metadataMenuItems" [popup]="true" appendTo="body"/>
                       <p-button
                         (click)="menu.toggle($event)"
-                        tooltip="Metadata actions"
+                        pTooltip="Metadata actions"
                         tooltipPosition="top"
                         outlined="true"
                         severity="info"
@@ -255,6 +257,14 @@
                     severity="info"
                     (click)="lockUnlockMetadata()"
                     pTooltip="Lock/Unlock metadata"
+                    tooltipPosition="top">
+                  </p-button>
+                  <p-button
+                    outlined="true"
+                    icon="pi pi-check-square"
+                    severity="success"
+                    (click)="selectAllBooks()"
+                    pTooltip="Select all books"
                     tooltipPosition="top">
                   </p-button>
                   <p-button

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.html
@@ -28,14 +28,11 @@
     <p-button [hidden]="readButtonHidden" [rounded]="true" icon="pi pi-book" class="read-btn" (click)="readBook(book)"></p-button>
 
     @if (isCheckboxEnabled) {
-      <p-checkbox
-        [(ngModel)]="isSelected"
-        binary="true"
-        id="select-checkbox-{{book.id}}"
-        name="select-checkbox-{{book.id}}"
+      <input
+        type="checkbox"
         class="select-checkbox"
-        (ngModelChange)="toggleSelection(isSelected || false)">
-      </p-checkbox>
+        [checked]="isSelected"
+        (click)="toggleSelection(!isSelected, $event)">
     }
 
     @if (progressPercentage !== null) {

--- a/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-card/book-card.component.ts
@@ -1,4 +1,4 @@
-import {Component, inject, Input, OnInit, ViewChild} from '@angular/core';
+import {Component, ElementRef, EventEmitter, inject, Input, OnInit, Output, ViewChild} from '@angular/core';
 import {Book, BookMetadata} from '../../../model/book.model';
 import {Button} from 'primeng/button';
 import {MenuModule} from 'primeng/menu';
@@ -12,7 +12,7 @@ import {MetadataFetchOptionsComponent} from '../../../metadata/metadata-options-
 import {MetadataRefreshType} from '../../../metadata/model/request/metadata-refresh-type.enum';
 import {MetadataRefreshRequest} from '../../../metadata/model/request/metadata-refresh-request.model';
 import {UrlHelperService} from '../../../../utilities/service/url-helper.service';
-import { NgClass } from '@angular/common';
+import {NgClass} from '@angular/common';
 import {UserService} from '../../../../settings/user-management/user.service';
 import {filter} from 'rxjs';
 import {EmailService} from '../../../../settings/email/email.service';
@@ -29,6 +29,9 @@ import {ProgressBar} from 'primeng/progressbar';
   standalone: true
 })
 export class BookCardComponent implements OnInit {
+  @Input() index!: number;
+  @Output() checkboxClick = new EventEmitter<{ index: number; bookId: number; selected: boolean; shiftKey: boolean }>();
+
   @Input() book!: Book;
   @Input() isCheckboxEnabled: boolean = false;
   @Input() onBookSelect?: (bookId: number, selected: boolean) => void;
@@ -36,6 +39,8 @@ export class BookCardComponent implements OnInit {
   @Input() bottomBarHidden: boolean = false;
   @Input() readButtonHidden: boolean = false;
   @Input() isSeriesCollapsed: boolean = false;
+
+  @ViewChild('checkboxElem') checkboxElem!: ElementRef<HTMLInputElement>;
 
   items: MenuItem[] | undefined;
   isHovered: boolean = false;
@@ -79,9 +84,16 @@ export class BookCardComponent implements OnInit {
     this.bookService.readBook(book.id);
   }
 
-  toggleSelection(selected: boolean): void {
+  toggleSelection(selected: boolean, event?: MouseEvent): void {
     if (this.isCheckboxEnabled) {
       this.isSelected = selected;
+      this.checkboxClick.emit({
+        index: this.index,
+        bookId: this.book.id,
+        selected,
+        shiftKey: !!event?.shiftKey,
+      });
+
       if (this.onBookSelect) {
         this.onBookSelect(this.book.id, selected);
       }

--- a/booklore-ui/src/app/book/components/book-browser/book-table/book-table.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-table/book-table.component.ts
@@ -45,6 +45,12 @@ export class BookTableComponent implements OnChanges {
     });
   }
 
+  selectAllBooks(): void {
+    this.selectedBookIds = new Set(this.books.map(book => book.id));
+    this.selectedBooks = [...this.books];
+    this.selectedBooksChange.emit(this.selectedBookIds);
+  }
+
   clearSelectedBooks(): void {
     this.selectedBookIds.clear();
     this.selectedBooks = [];


### PR DESCRIPTION
…l" support

- Implemented shift-click selection in grid view to allow selecting a range of books
- Tracked last selected index to determine selection range when shift key is pressed
- Maintained selected book IDs in a Set for fast lookup and deduplication
- Added a "Select All" button in the book browser footer to select all filtered books
- Synced selection state with PrimeNG checkbox behavior
- Ensured selection works correctly with filtered, sorted, or paginated results