### PR TITLE
[OPDS] Fix search option not recognized by MoonReader

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/config/security/SecurityConfig.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/config/security/SecurityConfig.java
@@ -56,6 +56,10 @@ public class SecurityConfig {
             "/api/v1/pdf/*/pages/*"
     };
 
+    private static final String[] COMMON_UNAUTHENTICATED_ENDPOINTS = {
+            "/api/v1/opds/search.opds"
+    };
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -64,11 +68,16 @@ public class SecurityConfig {
     @Bean
     @Order(1)
     public SecurityFilterChain opdsBasicAuthSecurityChain(HttpSecurity http) throws Exception {
+
+        List<String> unauthenticatedEndpoints = new ArrayList<>(Arrays.asList(COMMON_UNAUTHENTICATED_ENDPOINTS));
         http
                 .securityMatcher("/api/v1/opds/**")
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(unauthenticatedEndpoints.toArray(new String[0])).permitAll()
+                        .anyRequest().authenticated()
+                        )
                 .httpBasic(basic -> basic
                         .realmName("Booklore OPDS")
                         .authenticationEntryPoint((request, response, authException) -> {


### PR DESCRIPTION
MoonReader doesn't authenticate when making the GET request to get the search description
As this endpoint doesn't give out any library information , we can allow this endpoint without authenication.

![Screenshot_2025-06-24-10-11-41-74_9bd6c70c72493002d79393234a2b3cbd](https://github.com/user-attachments/assets/f237cec0-e9b9-4cf5-b92a-a24485584b7a)


