### PR TITLE
Bugfix: move read status tracking to per-user progress entity

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookEntity.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/BookEntity.java
@@ -10,7 +10,6 @@ import lombok.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -40,10 +39,6 @@ public class BookEntity {
 
     @Column(name = "metadata_match_score")
     private Float metadataMatchScore;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "read_status")
-    private ReadStatus readStatus;
 
     @OneToOne(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private BookMetadataEntity metadata;

--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/UserBookProgressEntity.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/entity/UserBookProgressEntity.java
@@ -1,5 +1,6 @@
 package com.adityachandel.booklore.model.entity;
 
+import com.adityachandel.booklore.model.enums.ReadStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,4 +47,8 @@ public class UserBookProgressEntity {
 
     @Column(name = "cbx_progress_percent")
     private Float cbxProgressPercent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "read_status")
+    private ReadStatus readStatus;
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/BookService.java
@@ -10,10 +10,8 @@ import com.adityachandel.booklore.model.entity.*;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.model.enums.ReadStatus;
 import com.adityachandel.booklore.repository.*;
-import com.adityachandel.booklore.service.appsettings.AppSettingService;
 import com.adityachandel.booklore.util.FileService;
 import com.adityachandel.booklore.util.FileUtils;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
@@ -270,6 +268,7 @@ public class BookService {
                     .build());
         }
         book.setFilePath(FileUtils.getBookFullPath(bookEntity));
+        book.setReadStatus(String.valueOf(userProgress.getReadStatus()));
 
         if (!withDescription) {
             book.getMetadata().setDescription(null);
@@ -333,6 +332,18 @@ public class BookService {
             userBookProgress.setCbxProgress(request.getCbxProgress().getPage());
             userBookProgress.setCbxProgressPercent(request.getCbxProgress().getPercentage());
         }
+        userBookProgressRepository.save(userBookProgress);
+    }
+
+    @Transactional
+    public void updateReadStatus(Long bookId, String status) {
+        BookEntity book = bookRepository.findById(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
+        BookLoreUser user = authenticationService.getAuthenticatedUser();
+        UserBookProgressEntity userBookProgress = userBookProgressRepository.findByUserIdAndBookId(user.getId(), book.getId()).orElse(new UserBookProgressEntity());
+        userBookProgress.setUser(userRepository.findById(user.getId()).orElseThrow(() -> new UsernameNotFoundException("User not found")));
+        userBookProgress.setBook(book);
+        ReadStatus readStatus = EnumUtils.getEnumIgnoreCase(ReadStatus.class, status);
+        userBookProgress.setReadStatus(readStatus);
         userBookProgressRepository.save(userBookProgress);
     }
 
@@ -454,12 +465,5 @@ public class BookService {
                 break;
             }
         }
-    }
-
-    public void updateReadStatus(long bookId, @NotBlank String status) {
-        BookEntity bookEntity = bookRepository.findById(bookId).orElseThrow(() -> ApiError.BOOK_NOT_FOUND.createException(bookId));
-        ReadStatus readStatus = EnumUtils.getEnumIgnoreCase(ReadStatus.class, status);
-        bookEntity.setReadStatus(readStatus);
-        bookRepository.save(bookEntity);
     }
 }

--- a/booklore-api/src/main/resources/db/migration/V36__Add_read_status_to_user_book_progress.sql
+++ b/booklore-api/src/main/resources/db/migration/V36__Add_read_status_to_user_book_progress.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_book_progress
+    ADD COLUMN read_status VARCHAR(20);


### PR DESCRIPTION
- Removed global `readStatus` field from `BookEntity`
- Added `read_status` column to `UserBookProgressEntity` for per-user tracking
- Added Flyway migration to introduce `read_status` column to `user_book_progress`