### PR TITLE
Persist cover scale preference per device using LocalStorage

### DIFF
--- a/booklore-ui/src/app/book/components/book-browser/book-browser.component.ts
+++ b/booklore-ui/src/app/book/components/book-browser/book-browser.component.ts
@@ -275,7 +275,7 @@ export class BookBrowserComponent implements OnInit, AfterViewInit {
       this.entityViewPreferences = user.userSettings?.entityViewPreferences;
       const globalPrefs = this.entityViewPreferences?.global;
       const currentEntityTypeStr = this.entityType ? this.entityType.toString().toUpperCase() : undefined;
-      this.coverScalePreferenceService.initScaleValue(user?.userSettings?.entityViewPreferences?.global?.coverSize);
+      this.coverScalePreferenceService.initScaleValue(this.coverScalePreferenceService.scaleFactor);
       this.filterSortPreferenceService.initValue(user?.userSettings?.filterSortingMode);
       this.columnPreferenceService.initPreferences(user.userSettings?.tableColumnPreference);
       this.visibleColumns = this.columnPreferenceService.visibleColumns;

--- a/booklore-ui/src/app/core/service/local-storage-service.ts
+++ b/booklore-ui/src/app/core/service/local-storage-service.ts
@@ -1,0 +1,25 @@
+import {Injectable} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class LocalStorageService {
+
+  get<T>(key: string): T | null {
+    try {
+      const value = localStorage.getItem(key);
+      return value ? JSON.parse(value) as T : null;
+    } catch {
+      return null;
+    }
+  }
+
+  set<T>(key: string, value: T): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+    }
+  }
+
+  remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+}

--- a/booklore-ui/src/app/settings/global-preferences/global-preferences.component.ts
+++ b/booklore-ui/src/app/settings/global-preferences/global-preferences.component.ts
@@ -15,7 +15,6 @@ import {BookService} from '../../book/service/book.service';
 import {AppSettingKey, AppSettings} from '../../core/model/app-settings.model';
 import {filter, take} from 'rxjs/operators';
 import {FileUploadPatternComponent} from './file-upload-pattern/file-upload-pattern.component';
-import {OpdsSettingsComponent} from './opds-settings/opds-settings.component';
 import {InputText} from 'primeng/inputtext';
 
 @Component({
@@ -30,7 +29,6 @@ import {InputText} from 'primeng/inputtext';
     ToggleSwitch,
     FormsModule,
     FileUploadPatternComponent,
-    OpdsSettingsComponent,
     InputText
   ],
   templateUrl: './global-preferences.component.html',


### PR DESCRIPTION
- Store cover scale preference locally to allow different settings per device (desktop, mobile)
- Disabled backend saving for cover scale but kept code commented for future reference
- Load scale preference from LocalStorage on init for faster and device-specific UX