### PR TITLE
Registry-based Architecture for Multiple Book Processing Modes

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookDropService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/bookdrop/BookDropService.java
@@ -167,10 +167,7 @@ public class BookDropService {
                 .fileName(fileName)
                 .build();
 
-        BookFileExtension extension = BookFileExtension.fromFileName(fileName)
-                .orElseThrow(() -> ApiError.INVALID_FILE_FORMAT.createException("Unsupported file extension"));
-
-        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(extension);
+        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(type);
         return processor.processFile(libraryFile);
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessor.java
@@ -3,12 +3,12 @@ package com.adityachandel.booklore.service.fileprocessor;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
-import com.adityachandel.booklore.model.enums.BookFileExtension;
+import com.adityachandel.booklore.model.enums.BookFileType;
 
 import java.util.List;
 
 public interface BookFileProcessor {
-    List<BookFileExtension> getSupportedExtensions();
+    List<BookFileType> getSupportedTypes();
     Book processFile(LibraryFile libraryFile);
     boolean generateCover(BookEntity bookEntity);
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessor.java
@@ -3,8 +3,12 @@ package com.adityachandel.booklore.service.fileprocessor;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.enums.BookFileExtension;
+
+import java.util.List;
 
 public interface BookFileProcessor {
+    List<BookFileExtension> getSupportedExtensions();
     Book processFile(LibraryFile libraryFile);
     boolean generateCover(BookEntity bookEntity);
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessorRegistry.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessorRegistry.java
@@ -1,6 +1,6 @@
 package com.adityachandel.booklore.service.fileprocessor;
 
-import com.adityachandel.booklore.model.enums.BookFileExtension;
+import com.adityachandel.booklore.model.enums.BookFileType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -13,32 +13,32 @@ import java.util.Optional;
 @Slf4j
 public class BookFileProcessorRegistry {
     
-    private final Map<BookFileExtension, BookFileProcessor> processorMap;
+    private final Map<BookFileType, BookFileProcessor> processorMap;
     
     public BookFileProcessorRegistry(List<BookFileProcessor> processors) {
-        this.processorMap = new EnumMap<>(BookFileExtension.class);
+        this.processorMap = new EnumMap<>(BookFileType.class);
         initializeProcessorMap(processors);
     }
     
     private void initializeProcessorMap(List<BookFileProcessor> processors) {
         for (BookFileProcessor processor : processors) {
-            List<BookFileExtension> supportedExtensions = processor.getSupportedExtensions();
-            for (BookFileExtension extension : supportedExtensions) {
-                processorMap.put(extension, processor);
-                log.debug("Registered {} for extension: {}", processor.getClass().getSimpleName(), extension);
+            List<BookFileType> supportedTypes = processor.getSupportedTypes();
+            for (BookFileType type : supportedTypes) {
+                processorMap.put(type, processor);
+                log.debug("Registered {} for type: {}", processor.getClass().getSimpleName(), type);
             }
         }
-        log.info("Initialized BookFileProcessorRegistry with {} processors for {} extensions", 
+        log.info("Initialized BookFileProcessorRegistry with {} processors for {} types", 
                 processors.size(), processorMap.size());
     }
     
-    public Optional<BookFileProcessor> getProcessor(BookFileExtension extension) {
-        return Optional.ofNullable(processorMap.get(extension));
+    public Optional<BookFileProcessor> getProcessor(BookFileType type) {
+        return Optional.ofNullable(processorMap.get(type));
     }
     
-    public BookFileProcessor getProcessorOrThrow(BookFileExtension extension) {
-        return getProcessor(extension)
+    public BookFileProcessor getProcessorOrThrow(BookFileType type) {
+        return getProcessor(type)
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "No processor found for file extension: " + extension));
+                        "No processor found for file type: " + type));
     }
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessorRegistry.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/BookFileProcessorRegistry.java
@@ -1,0 +1,44 @@
+package com.adityachandel.booklore.service.fileprocessor;
+
+import com.adityachandel.booklore.model.enums.BookFileExtension;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class BookFileProcessorRegistry {
+    
+    private final Map<BookFileExtension, BookFileProcessor> processorMap;
+    
+    public BookFileProcessorRegistry(List<BookFileProcessor> processors) {
+        this.processorMap = new EnumMap<>(BookFileExtension.class);
+        initializeProcessorMap(processors);
+    }
+    
+    private void initializeProcessorMap(List<BookFileProcessor> processors) {
+        for (BookFileProcessor processor : processors) {
+            List<BookFileExtension> supportedExtensions = processor.getSupportedExtensions();
+            for (BookFileExtension extension : supportedExtensions) {
+                processorMap.put(extension, processor);
+                log.debug("Registered {} for extension: {}", processor.getClass().getSimpleName(), extension);
+            }
+        }
+        log.info("Initialized BookFileProcessorRegistry with {} processors for {} extensions", 
+                processors.size(), processorMap.size());
+    }
+    
+    public Optional<BookFileProcessor> getProcessor(BookFileExtension extension) {
+        return Optional.ofNullable(processorMap.get(extension));
+    }
+    
+    public BookFileProcessor getProcessorOrThrow(BookFileExtension extension) {
+        return getProcessor(extension)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No processor found for file extension: " + extension));
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
@@ -4,6 +4,7 @@ import com.adityachandel.booklore.mapper.BookMapper;
 import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
@@ -68,6 +69,11 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
             log.error("Error generating cover for '{}': {}", bookEntity.getFileName(), e.getMessage());
         }
         return false;
+    }
+
+    @Override
+    public List<BookFileExtension> getSupportedExtensions() {
+        return List.of(BookFileExtension.CBZ, BookFileExtension.CBR, BookFileExtension.CB7);
     }
 
     private Optional<BufferedImage> extractImagesFromArchive(File file) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/CbxProcessor.java
@@ -1,10 +1,8 @@
 package com.adityachandel.booklore.service.fileprocessor;
 
 import com.adityachandel.booklore.mapper.BookMapper;
-import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
-import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
@@ -72,8 +70,8 @@ public class CbxProcessor extends AbstractFileProcessor implements BookFileProce
     }
 
     @Override
-    public List<BookFileExtension> getSupportedExtensions() {
-        return List.of(BookFileExtension.CBZ, BookFileExtension.CBR, BookFileExtension.CB7);
+    public List<BookFileType> getSupportedTypes() {
+        return List.of(BookFileType.CBX);
     }
 
     private Optional<BufferedImage> extractImagesFromArchive(File file) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
@@ -5,7 +5,6 @@ import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.entity.BookMetadataEntity;
-import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
@@ -95,8 +94,8 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
     }
 
     @Override
-    public List<BookFileExtension> getSupportedExtensions() {
-        return List.of(BookFileExtension.EPUB);
+    public List<BookFileType> getSupportedTypes() {
+        return List.of(BookFileType.EPUB);
     }
 
     private void setBookMetadata(BookEntity bookEntity) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/EpubProcessor.java
@@ -5,6 +5,7 @@ import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
@@ -21,6 +22,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -90,6 +92,11 @@ public class EpubProcessor extends AbstractFileProcessor implements BookFileProc
             log.error("Error generating cover for EPUB '{}': {}", bookEntity.getFileName(), e.getMessage(), e);
             return false;
         }
+    }
+
+    @Override
+    public List<BookFileExtension> getSupportedExtensions() {
+        return List.of(BookFileExtension.EPUB);
     }
 
     private void setBookMetadata(BookEntity bookEntity) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/PdfProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/PdfProcessor.java
@@ -4,7 +4,6 @@ import com.adityachandel.booklore.mapper.BookMapper;
 import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
-import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
@@ -71,8 +70,8 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
     }
 
     @Override
-    public List<BookFileExtension> getSupportedExtensions() {
-        return List.of(BookFileExtension.PDF);
+    public List<BookFileType> getSupportedTypes() {
+        return List.of(BookFileType.PDF);
     }
 
     private void extractAndSetMetadata(BookEntity bookEntity) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/PdfProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/fileprocessor/PdfProcessor.java
@@ -4,6 +4,7 @@ import com.adityachandel.booklore.mapper.BookMapper;
 import com.adityachandel.booklore.model.dto.BookMetadata;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.BookEntity;
+import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.repository.BookMetadataRepository;
 import com.adityachandel.booklore.repository.BookRepository;
@@ -23,6 +24,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 
 import static com.adityachandel.booklore.service.fileprocessor.FileProcessingUtils.truncate;
 
@@ -66,6 +68,11 @@ public class PdfProcessor extends AbstractFileProcessor implements BookFileProce
             log.warn("Failed to generate cover for '{}': {}", bookEntity.getFileName(), e.getMessage());
             return false;
         }
+    }
+
+    @Override
+    public List<BookFileExtension> getSupportedExtensions() {
+        return List.of(BookFileExtension.PDF);
     }
 
     private void extractAndSetMetadata(BookEntity bookEntity) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/FileAsBookProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/FileAsBookProcessor.java
@@ -4,6 +4,7 @@ import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.LibraryEntity;
 import com.adityachandel.booklore.model.enums.BookFileExtension;
+import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.model.websocket.Topic;
 import com.adityachandel.booklore.service.NotificationService;
 import com.adityachandel.booklore.service.fileprocessor.BookFileProcessor;
@@ -41,13 +42,13 @@ public class FileAsBookProcessor implements LibraryFileProcessor {
 
     @Transactional
     protected Book processLibraryFile(LibraryFile libraryFile) {
-        BookFileExtension extension = BookFileExtension.fromFileName(libraryFile.getFileName()).orElse(null);
-        if (extension == null) {
+        BookFileType type = libraryFile.getBookFileType();
+        if (type == null) {
             log.warn("Unsupported file type for file: {}", libraryFile.getFileName());
             return null;
         }
 
-        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(extension);
+        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(type);
         return processor.processFile(libraryFile);
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/FileAsBookProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/FileAsBookProcessor.java
@@ -1,0 +1,52 @@
+package com.adityachandel.booklore.service.library;
+
+import com.adityachandel.booklore.model.dto.Book;
+import com.adityachandel.booklore.model.dto.settings.LibraryFile;
+import com.adityachandel.booklore.model.entity.LibraryEntity;
+import com.adityachandel.booklore.model.websocket.Topic;
+import com.adityachandel.booklore.service.NotificationService;
+import com.adityachandel.booklore.service.fileprocessor.CbxProcessor;
+import com.adityachandel.booklore.service.fileprocessor.EpubProcessor;
+import com.adityachandel.booklore.service.fileprocessor.PdfProcessor;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.adityachandel.booklore.model.websocket.LogNotification.createLogNotification;
+
+@AllArgsConstructor
+@Component
+@Slf4j
+public class FileAsBookProcessor implements LibraryFileProcessor {
+    
+    private final NotificationService notificationService;
+    private final PdfProcessor pdfProcessor;
+    private final EpubProcessor epubProcessor;
+    private final CbxProcessor cbxProcessor;
+
+    @Override
+    @Transactional
+    public void processLibraryFiles(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) {
+        for (LibraryFile libraryFile : libraryFiles) {
+            log.info("Processing file: {}", libraryFile.getFileName());
+            Book book = processLibraryFile(libraryFile);
+            if (book != null) {
+                notificationService.sendMessage(Topic.BOOK_ADD, book);
+                notificationService.sendMessage(Topic.LOG, createLogNotification("Book added: " + book.getFileName()));
+                log.info("Processed file: {}", libraryFile.getFileName());
+            }
+        }
+    }
+
+    @Transactional
+    protected Book processLibraryFile(LibraryFile libraryFile) {
+        return switch (libraryFile.getBookFileType()) {
+            case PDF -> pdfProcessor.processFile(libraryFile);
+            case EPUB -> epubProcessor.processFile(libraryFile);
+            case CBX -> cbxProcessor.processFile(libraryFile);
+        };
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessor.java
@@ -1,0 +1,10 @@
+package com.adityachandel.booklore.service.library;
+
+import com.adityachandel.booklore.model.dto.settings.LibraryFile;
+import com.adityachandel.booklore.model.entity.LibraryEntity;
+
+import java.util.List;
+
+public interface LibraryFileProcessor {
+    void processLibraryFiles(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity);
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
@@ -4,8 +4,7 @@ import com.adityachandel.booklore.model.entity.LibraryEntity;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Map;
+// Removed unused imports
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
@@ -1,0 +1,21 @@
+package com.adityachandel.booklore.service.library;
+
+import com.adityachandel.booklore.model.entity.LibraryEntity;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@Component
+public class LibraryFileProcessorRegistry {
+
+    private final FileAsBookProcessor fileAsBookProcessor;
+
+    public LibraryFileProcessor getProcessor(LibraryEntity library) {
+        return fileAsBookProcessor;
+    }
+}

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 // Removed unused imports
-import java.util.function.Function;
 @AllArgsConstructor
 @Component
 public class LibraryFileProcessorRegistry {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryFileProcessorRegistry.java
@@ -6,8 +6,6 @@ import org.springframework.stereotype.Component;
 
 // Removed unused imports
 import java.util.function.Function;
-import java.util.stream.Collectors;
-
 @AllArgsConstructor
 @Component
 public class LibraryFileProcessorRegistry {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryProcessingService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryProcessingService.java
@@ -63,7 +63,7 @@ public class LibraryProcessingService {
         notificationService.sendMessage(Topic.LOG, createLogNotification("Finished refreshing library: " + libraryEntity.getName()));
     }
 
-    public static List<Long> detectDeletedBookIds(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) throws IOException {
+    public static List<Long> detectDeletedBookIds(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) {
         Set<String> currentFileNames = libraryFiles.stream()
                 .map(LibraryFile::getFileName)
                 .collect(Collectors.toSet());
@@ -75,7 +75,7 @@ public class LibraryProcessingService {
                 .collect(Collectors.toList());
     }
 
-    public static List<LibraryFile> detectNewBookPaths(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) throws IOException {
+    public static List<LibraryFile> detectNewBookPaths(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) {
         Set<String> existingFileNames = libraryEntity.getBookEntities().stream()
                 .map(BookEntity::getFileName)
                 .collect(Collectors.toSet());

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryProcessingService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/library/LibraryProcessingService.java
@@ -62,23 +62,23 @@ public class LibraryProcessingService {
     }
 
     public static List<Long> detectDeletedBookIds(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) {
-        Set<String> currentFileNames = libraryFiles.stream()
-                .map(LibraryFile::getFileName)
+        Set<Path> currentFullPaths = libraryFiles.stream()
+                .map(LibraryFile::getFullPath)
                 .collect(Collectors.toSet());
 
         return libraryEntity.getBookEntities().stream()
                 .filter(book -> (book.getDeleted() == null || !book.getDeleted()))
-                .filter(book -> !currentFileNames.contains(book.getFileName()))
+                .filter(book -> !currentFullPaths.contains(book.getFullFilePath()))
                 .map(BookEntity::getId)
                 .collect(Collectors.toList());
     }
 
     public static List<LibraryFile> detectNewBookPaths(List<LibraryFile> libraryFiles, LibraryEntity libraryEntity) {
-        Set<String> existingFileNames = libraryEntity.getBookEntities().stream()
-                .map(BookEntity::getFileName)
+        Set<Path> existingFullPaths = libraryEntity.getBookEntities().stream()
+                .map(BookEntity::getFullFilePath)
                 .collect(Collectors.toSet());
         return libraryFiles.stream()
-                .filter(file -> !existingFileNames.contains(file.getFileName()))
+                .filter(file -> !existingFullPaths.contains(file.getFullPath()))
                 .collect(Collectors.toList());
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataService.java
@@ -194,11 +194,8 @@ public class BookMetadataService {
         String title = book.getMetadata().getTitle();
         String message = progress + "Regenerating cover for: " + title;
         notificationService.sendMessage(Topic.LOG, createLogNotification(message));
-        
-        BookFileExtension extension = BookFileExtension.fromFileName(book.getFileName())
-                .orElseThrow(() -> ApiError.UNSUPPORTED_BOOK_TYPE.createException(book.getBookType()));
 
-        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(extension);
+        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(book.getBookType());
         processor.generateCover(book);
 
         log.info("{}Successfully regenerated cover for book ID {} ({})", progress, book.getId(), title);

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/BookMetadataService.java
@@ -13,6 +13,7 @@ import com.adityachandel.booklore.model.dto.request.FetchMetadataRequest;
 import com.adityachandel.booklore.model.dto.request.ToggleAllLockRequest;
 import com.adityachandel.booklore.model.entity.BookEntity;
 import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.Lock;
 import com.adityachandel.booklore.model.enums.MetadataProvider;
 import com.adityachandel.booklore.model.websocket.Topic;
@@ -21,9 +22,8 @@ import com.adityachandel.booklore.repository.BookRepository;
 import com.adityachandel.booklore.service.BookQueryService;
 import com.adityachandel.booklore.service.NotificationService;
 import com.adityachandel.booklore.service.appsettings.AppSettingService;
-import com.adityachandel.booklore.service.fileprocessor.CbxProcessor;
-import com.adityachandel.booklore.service.fileprocessor.EpubProcessor;
-import com.adityachandel.booklore.service.fileprocessor.PdfProcessor;
+import com.adityachandel.booklore.service.fileprocessor.BookFileProcessor;
+import com.adityachandel.booklore.service.fileprocessor.BookFileProcessorRegistry;
 import com.adityachandel.booklore.service.metadata.backuprestore.MetadataBackupRestore;
 import com.adityachandel.booklore.service.metadata.backuprestore.MetadataBackupRestoreFactory;
 import com.adityachandel.booklore.service.metadata.parser.BookParser;
@@ -61,9 +61,7 @@ public class BookMetadataService {
     private final AppSettingService appSettingService;
     private final BookMetadataRepository bookMetadataRepository;
     private final FileService fileService;
-    private final PdfProcessor pdfProcessor;
-    private final EpubProcessor epubProcessor;
-    private final CbxProcessor cbxProcessor;
+    private final BookFileProcessorRegistry processorRegistry;
     private final BookQueryService bookQueryService;
     private final Map<MetadataProvider, BookParser> parserMap;
     private final MetadataBackupRestoreFactory metadataBackupRestoreFactory;
@@ -196,12 +194,13 @@ public class BookMetadataService {
         String title = book.getMetadata().getTitle();
         String message = progress + "Regenerating cover for: " + title;
         notificationService.sendMessage(Topic.LOG, createLogNotification(message));
-        switch (book.getBookType()) {
-            case PDF -> pdfProcessor.generateCover(book);
-            case EPUB -> epubProcessor.generateCover(book);
-            case CBX -> cbxProcessor.generateCover(book);
-            default -> throw ApiError.UNSUPPORTED_BOOK_TYPE.createException(book.getBookType());
-        }
+        
+        BookFileExtension extension = BookFileExtension.fromFileName(book.getFileName())
+                .orElseThrow(() -> ApiError.UNSUPPORTED_BOOK_TYPE.createException(book.getBookType()));
+
+        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(extension);
+        processor.generateCover(book);
+
         log.info("{}Successfully regenerated cover for book ID {} ({})", progress, book.getId(), title);
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/upload/FileUploadService.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/upload/FileUploadService.java
@@ -81,7 +81,7 @@ public class FileUploadService {
 
         try {
             file.transferTo(tempPath);
-            
+
             setTemporaryFileOwnership(tempPath);
 
             BookFileExtension fileExt = BookFileExtension.fromFileName(file.getOriginalFilename()).orElseThrow(() -> ApiError.INVALID_FILE_FORMAT.createException("Unsupported file extension"));
@@ -164,21 +164,18 @@ public class FileUploadService {
         }
     }
 
-    private Book processFile(String fileName, LibraryEntity libraryEntity, LibraryPathEntity libraryPathEntity, File storageFile, BookFileType fileType) {
+    private Book processFile(String fileName, LibraryEntity libraryEntity, LibraryPathEntity libraryPathEntity, File storageFile, BookFileType type) {
         String subPath = FileUtils.getRelativeSubPath(libraryPathEntity.getPath(), storageFile.toPath());
 
         LibraryFile libraryFile = LibraryFile.builder()
                 .libraryEntity(libraryEntity)
                 .libraryPathEntity(libraryPathEntity)
                 .fileSubPath(subPath)
-                .bookFileType(fileType)
+                .bookFileType(type)
                 .fileName(fileName)
                 .build();
 
-        BookFileExtension extension = BookFileExtension.fromFileName(fileName)
-                .orElseThrow(() -> ApiError.INVALID_FILE_FORMAT.createException("Unsupported file extension"));
-
-        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(extension);
+        BookFileProcessor processor = processorRegistry.getProcessorOrThrow(type);
         return processor.processFile(libraryFile);
     }
 

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/watcher/BookFileTransactionalHandler.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/watcher/BookFileTransactionalHandler.java
@@ -62,7 +62,7 @@ public class BookFileTransactionalHandler {
                         .orElseThrow(() -> new IllegalArgumentException("Unsupported book file type: " + fileName)))
                 .build();
 
-        libraryProcessingService.processLibraryFiles(List.of(libraryFile));
+        libraryProcessingService.processLibraryFiles(List.of(libraryFile), libraryEntity);
 
         notificationService.sendMessage(Topic.LOG, createLogNotification("Finished processing file: " + filePath));
         log.info("[CREATE] Completed processing for file '{}'", filePath);

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/BookDropServiceTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/BookDropServiceTest.java
@@ -6,12 +6,11 @@ import com.adityachandel.booklore.repository.BookdropFileRepository;
 import com.adityachandel.booklore.repository.LibraryRepository;
 import com.adityachandel.booklore.service.bookdrop.BookDropService;
 import com.adityachandel.booklore.service.bookdrop.BookdropNotificationService;
-import com.adityachandel.booklore.service.fileprocessor.CbxProcessor;
-import com.adityachandel.booklore.service.fileprocessor.EpubProcessor;
-import com.adityachandel.booklore.service.fileprocessor.PdfProcessor;
+import com.adityachandel.booklore.service.fileprocessor.BookFileProcessorRegistry;
 import com.adityachandel.booklore.service.metadata.MetadataRefreshService;
 import com.adityachandel.booklore.service.bookdrop.BookdropMonitoringService;
 import com.adityachandel.booklore.service.monitoring.MonitoringService;
+import com.adityachandel.booklore.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.PathResource;
@@ -35,9 +34,6 @@ class BookDropServiceTest {
     private NotificationService notificationService;
     private MetadataRefreshService metadataRefreshService;
     private BookdropNotificationService bookdropNotificationService;
-    private PdfProcessor pdfProcessor;
-    private EpubProcessor epubProcessor;
-    private CbxProcessor cbxProcessor;
     private AppProperties appProperties;
 
     private BookDropService bookDropService;
@@ -52,9 +48,7 @@ class BookDropServiceTest {
         notificationService = mock(NotificationService.class);
         metadataRefreshService = mock(MetadataRefreshService.class);
         bookdropNotificationService = mock(BookdropNotificationService.class);
-        pdfProcessor = mock(PdfProcessor.class);
-        epubProcessor = mock(EpubProcessor.class);
-        cbxProcessor = mock(CbxProcessor.class);
+        BookFileProcessorRegistry processorRegistry = mock(BookFileProcessorRegistry.class);
         appProperties = mock(AppProperties.class);
 
         bookDropService = new BookDropService(
@@ -62,7 +56,7 @@ class BookDropServiceTest {
                 monitoringService, bookdropMonitoringService,
                 notificationService, metadataRefreshService,
                 bookdropNotificationService,
-                pdfProcessor, epubProcessor, cbxProcessor,
+                processorRegistry,
                 appProperties
         );
     }
@@ -110,7 +104,7 @@ class BookDropServiceTest {
         Resource resource = bookDropService.getBookdropCover(bookdropId);
 
         assertThat(resource).isInstanceOf(PathResource.class);
-        assertThat(((PathResource) resource).getFile().getName()).isEqualTo(bookdropId + ".jpg");
+        assertThat(resource.getFilename()).isEqualTo(bookdropId + ".jpg");
 
         coverFile.delete();
     }

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/library/FileAsBookProcessorTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/library/FileAsBookProcessorTest.java
@@ -4,7 +4,6 @@ import com.adityachandel.booklore.model.dto.Book;
 import com.adityachandel.booklore.model.dto.settings.LibraryFile;
 import com.adityachandel.booklore.model.entity.LibraryEntity;
 import com.adityachandel.booklore.model.entity.LibraryPathEntity;
-import com.adityachandel.booklore.model.enums.BookFileExtension;
 import com.adityachandel.booklore.model.enums.BookFileType;
 import com.adityachandel.booklore.model.websocket.LogNotification;
 import com.adityachandel.booklore.model.websocket.Topic;
@@ -94,8 +93,8 @@ class FileAsBookProcessorTest {
                 .bookType(BookFileType.PDF)
                 .build();
         
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.PDF)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.PDF)).thenReturn(bookFileProcessor);
         when(bookFileProcessor.processFile(file1)).thenReturn(book1);
         when(bookFileProcessor.processFile(file2)).thenReturn(book2);
         
@@ -144,7 +143,7 @@ class FileAsBookProcessorTest {
                 .bookType(BookFileType.EPUB)
                 .build();
         
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.EPUB)).thenReturn(bookFileProcessor);
         when(bookFileProcessor.processFile(validFile)).thenReturn(book);
         
         // When
@@ -214,7 +213,7 @@ class FileAsBookProcessorTest {
                 .bookType(BookFileType.EPUB)
                 .build();
         
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.EPUB)).thenReturn(bookFileProcessor);
         when(bookFileProcessor.processFile(libraryFile)).thenReturn(expectedBook);
         
         // When
@@ -222,7 +221,7 @@ class FileAsBookProcessorTest {
         
         // Then
         assertThat(result).isEqualTo(expectedBook);
-        verify(processorRegistry).getProcessorOrThrow(BookFileExtension.EPUB);
+        verify(processorRegistry).getProcessorOrThrow(BookFileType.EPUB);
         verify(bookFileProcessor).processFile(libraryFile);
     }
 
@@ -241,7 +240,7 @@ class FileAsBookProcessorTest {
                 .bookFileType(BookFileType.PDF)
                 .build();
         
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.PDF)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.PDF)).thenReturn(bookFileProcessor);
         when(bookFileProcessor.processFile(libraryFile)).thenReturn(null);
         
         // When
@@ -269,7 +268,7 @@ class FileAsBookProcessorTest {
         
         libraryFiles.add(file);
         
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.EPUB)).thenReturn(bookFileProcessor);
         when(bookFileProcessor.processFile(file)).thenReturn(null);
         
         // When
@@ -344,11 +343,10 @@ class FileAsBookProcessorTest {
                 .bookType(BookFileType.CBX)
                 .build();
         
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.PDF)).thenReturn(bookFileProcessor);
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.CBZ)).thenReturn(bookFileProcessor);
-        when(processorRegistry.getProcessorOrThrow(BookFileExtension.CBR)).thenReturn(bookFileProcessor);
-        
+        when(processorRegistry.getProcessorOrThrow(BookFileType.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.PDF)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileType.CBX)).thenReturn(bookFileProcessor);
+
         when(bookFileProcessor.processFile(epubFile)).thenReturn(epubBook);
         when(bookFileProcessor.processFile(pdfFile)).thenReturn(pdfBook);
         when(bookFileProcessor.processFile(cbzFile)).thenReturn(cbzBook);

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/library/FileAsBookProcessorTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/library/FileAsBookProcessorTest.java
@@ -1,0 +1,364 @@
+package com.adityachandel.booklore.service.library;
+
+import com.adityachandel.booklore.model.dto.Book;
+import com.adityachandel.booklore.model.dto.settings.LibraryFile;
+import com.adityachandel.booklore.model.entity.LibraryEntity;
+import com.adityachandel.booklore.model.entity.LibraryPathEntity;
+import com.adityachandel.booklore.model.enums.BookFileExtension;
+import com.adityachandel.booklore.model.enums.BookFileType;
+import com.adityachandel.booklore.model.websocket.LogNotification;
+import com.adityachandel.booklore.model.websocket.Topic;
+import com.adityachandel.booklore.service.NotificationService;
+import com.adityachandel.booklore.service.fileprocessor.BookFileProcessor;
+import com.adityachandel.booklore.service.fileprocessor.BookFileProcessorRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class FileAsBookProcessorTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private BookFileProcessorRegistry processorRegistry;
+
+    @Mock
+    private BookFileProcessor bookFileProcessor;
+
+    @InjectMocks
+    private FileAsBookProcessor fileAsBookProcessor;
+
+    @Captor
+    private ArgumentCaptor<Book> bookCaptor;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    void processLibraryFiles_shouldProcessAllValidFiles() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        List<LibraryFile> libraryFiles = new ArrayList<>();
+        
+        LibraryFile file1 = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book1.epub")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+        
+        LibraryFile file2 = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book2.pdf")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.PDF)
+                .build();
+        
+        libraryFiles.add(file1);
+        libraryFiles.add(file2);
+        
+        Book book1 = Book.builder()
+                .fileName("book1.epub")
+                .title("Book 1")
+                .bookType(BookFileType.EPUB)
+                .build();
+        
+        Book book2 = Book.builder()
+                .fileName("book2.pdf")
+                .title("Book 2")
+                .bookType(BookFileType.PDF)
+                .build();
+        
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.PDF)).thenReturn(bookFileProcessor);
+        when(bookFileProcessor.processFile(file1)).thenReturn(book1);
+        when(bookFileProcessor.processFile(file2)).thenReturn(book2);
+        
+        // When
+        fileAsBookProcessor.processLibraryFiles(libraryFiles, libraryEntity);
+        
+        // Then
+        verify(notificationService, times(2)).sendMessage(eq(Topic.BOOK_ADD), bookCaptor.capture());
+        verify(notificationService, times(2)).sendMessage(eq(Topic.LOG), any(LogNotification.class));
+        
+        List<Book> capturedBooks = bookCaptor.getAllValues();
+        assertThat(capturedBooks).hasSize(2);
+        assertThat(capturedBooks).containsExactly(book1, book2);
+    }
+
+    @Test
+    void processLibraryFiles_shouldSkipFilesWithUnsupportedExtensions() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        List<LibraryFile> libraryFiles = new ArrayList<>();
+        
+        LibraryFile validFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book.epub")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+        
+        LibraryFile invalidFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("document.txt")
+                .fileSubPath("docs")
+                .bookFileType(null)
+                .build();
+        
+        libraryFiles.add(validFile);
+        libraryFiles.add(invalidFile);
+        
+        Book book = Book.builder()
+                .fileName("book.epub")
+                .title("Valid Book")
+                .bookType(BookFileType.EPUB)
+                .build();
+        
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(bookFileProcessor.processFile(validFile)).thenReturn(book);
+        
+        // When
+        fileAsBookProcessor.processLibraryFiles(libraryFiles, libraryEntity);
+        
+        // Then
+        verify(notificationService, times(1)).sendMessage(eq(Topic.BOOK_ADD), eq(book));
+        verify(notificationService, times(1)).sendMessage(eq(Topic.LOG), any(LogNotification.class));
+        verify(processorRegistry, times(1)).getProcessorOrThrow(any());
+    }
+
+    @Test
+    void processLibraryFiles_shouldHandleEmptyList() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        List<LibraryFile> libraryFiles = new ArrayList<>();
+        
+        // When
+        fileAsBookProcessor.processLibraryFiles(libraryFiles, libraryEntity);
+        
+        // Then
+        verify(notificationService, never()).sendMessage(any(Topic.class), any());
+        verify(processorRegistry, never()).getProcessorOrThrow(any());
+    }
+
+    @Test
+    void processLibraryFile_shouldReturnNullForUnsupportedFileType() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        
+        LibraryFile libraryFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("document.txt")
+                .fileSubPath("docs")
+                .bookFileType(null)
+                .build();
+        
+        // When
+        Book result = fileAsBookProcessor.processLibraryFile(libraryFile);
+        
+        // Then
+        assertThat(result).isNull();
+        verify(processorRegistry, never()).getProcessorOrThrow(any());
+    }
+
+    @Test
+    void processLibraryFile_shouldProcessSupportedFileTypes() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        
+        LibraryFile libraryFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book.epub")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+        
+        Book expectedBook = Book.builder()
+                .fileName("book.epub")
+                .title("Test Book")
+                .bookType(BookFileType.EPUB)
+                .build();
+        
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(bookFileProcessor.processFile(libraryFile)).thenReturn(expectedBook);
+        
+        // When
+        Book result = fileAsBookProcessor.processLibraryFile(libraryFile);
+        
+        // Then
+        assertThat(result).isEqualTo(expectedBook);
+        verify(processorRegistry).getProcessorOrThrow(BookFileExtension.EPUB);
+        verify(bookFileProcessor).processFile(libraryFile);
+    }
+
+    @Test
+    void processLibraryFile_shouldHandleNullReturnFromProcessor() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        
+        LibraryFile libraryFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book.pdf")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.PDF)
+                .build();
+        
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.PDF)).thenReturn(bookFileProcessor);
+        when(bookFileProcessor.processFile(libraryFile)).thenReturn(null);
+        
+        // When
+        Book result = fileAsBookProcessor.processLibraryFile(libraryFile);
+        
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void processLibraryFiles_shouldNotSendNotificationWhenProcessorReturnsNull() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        List<LibraryFile> libraryFiles = new ArrayList<>();
+        
+        LibraryFile file = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book.epub")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+        
+        libraryFiles.add(file);
+        
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(bookFileProcessor.processFile(file)).thenReturn(null);
+        
+        // When
+        fileAsBookProcessor.processLibraryFiles(libraryFiles, libraryEntity);
+        
+        // Then
+        verify(notificationService, never()).sendMessage(any(Topic.class), any());
+    }
+
+    @Test
+    void processLibraryFiles_shouldProcessAllSupportedFileExtensions() {
+        // Given
+        LibraryEntity libraryEntity = new LibraryEntity();
+        LibraryPathEntity libraryPathEntity = new LibraryPathEntity();
+        libraryPathEntity.setPath("/library/path");
+        List<LibraryFile> libraryFiles = new ArrayList<>();
+        
+        LibraryFile epubFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book.epub")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.EPUB)
+                .build();
+        
+        LibraryFile pdfFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("book.pdf")
+                .fileSubPath("books")
+                .bookFileType(BookFileType.PDF)
+                .build();
+        
+        LibraryFile cbzFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("comic.cbz")
+                .fileSubPath("comics")
+                .bookFileType(BookFileType.CBX)
+                .build();
+        
+        LibraryFile cbrFile = LibraryFile.builder()
+                .libraryEntity(libraryEntity)
+                .libraryPathEntity(libraryPathEntity)
+                .fileName("comic.cbr")
+                .fileSubPath("comics")
+                .bookFileType(BookFileType.CBX)
+                .build();
+        
+        libraryFiles.add(epubFile);
+        libraryFiles.add(pdfFile);
+        libraryFiles.add(cbzFile);
+        libraryFiles.add(cbrFile);
+        
+        Book epubBook = Book.builder()
+                .fileName("book.epub")
+                .bookType(BookFileType.EPUB)
+                .build();
+        
+        Book pdfBook = Book.builder()
+                .fileName("book.pdf")
+                .bookType(BookFileType.PDF)
+                .build();
+        
+        Book cbzBook = Book.builder()
+                .fileName("comic.cbz")
+                .bookType(BookFileType.CBX)
+                .build();
+        
+        Book cbrBook = Book.builder()
+                .fileName("comic.cbr")
+                .bookType(BookFileType.CBX)
+                .build();
+        
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.EPUB)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.PDF)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.CBZ)).thenReturn(bookFileProcessor);
+        when(processorRegistry.getProcessorOrThrow(BookFileExtension.CBR)).thenReturn(bookFileProcessor);
+        
+        when(bookFileProcessor.processFile(epubFile)).thenReturn(epubBook);
+        when(bookFileProcessor.processFile(pdfFile)).thenReturn(pdfBook);
+        when(bookFileProcessor.processFile(cbzFile)).thenReturn(cbzBook);
+        when(bookFileProcessor.processFile(cbrFile)).thenReturn(cbrBook);
+        
+        // When
+        fileAsBookProcessor.processLibraryFiles(libraryFiles, libraryEntity);
+        
+        // Then
+        verify(notificationService, times(4)).sendMessage(eq(Topic.BOOK_ADD), any(Book.class));
+        verify(notificationService, times(4)).sendMessage(eq(Topic.LOG), any(LogNotification.class));
+    }
+}


### PR DESCRIPTION
# 🚀 Feature: Registry-based Architecture for Multiple Book Processing Modes

> [!WARNING]
>
> I can't change base branch to `feature/file-processing-refactoring` branch from my fork.
> In result PR has changes from both branches. It will be fixed when #751 will be merged

## Overview

This PR introduces a registry-based architecture for book file processing, building upon the refactoring work from the previous [PR](#751). This enhancement creates a flexible foundation for supporting multiple library scan modes and book file formats, addressing the extensibility requirements for future features.

## Context

This is the second PR in the series, following the interface consolidation work in `feature/file-processing-refactoring`. The changes in this PR establish the architectural pattern that will enable more sophisticated library processing capabilities.

## Key Architectural Improvements

### 1. Registry Pattern for Book File Processors

I've introduced `BookFileProcessorRegistry` to centralize the management of file processors based on file extensions. This approach provides several benefits:
- **Type safety**: Using `EnumMap` ensures compile-time safety for supported extensions
- **Extensibility**: New processors can be added without modifying existing code
- **Performance**: O(1) lookup for processor selection
- **Clear separation**: Each processor declares its supported extensions via the new `getSupportedExtensions()` method

The codebase already has 3 places where the same code with `switch` by extension is used:

```java
return switch (libraryFile.getBookFileType()) {
    case PDF -> pdfProcessor.processFile(libraryFile);
    case EPUB -> epubProcessor.processFile(libraryFile);
    case CBX -> cbxProcessor.processFile(libraryFile);
};
```

Now all this logic consolidated in `BookFileProcessorRegistry` that has dictionary of processor by extension, so all places where type has been used is processed by registry instead:

```java
BookFileExtension extension = BookFileExtension.fromFileName(libraryFile.getFileName());
BookFileProcessor processor = processorRegistry.getProcessorOrThrow(extension);
return processor.processFile(libraryFile);
```

### 2. Modular Library Processing Architecture

The new `LibraryFileProcessor` interface and `LibraryFileProcessorRegistry` establish a pattern for different library scanning modes:
- **Current implementation**: `FileAsBookProcessor` handles the traditional file-as-book processing
- **Future-ready**: Architecture supports additional modes (folder-as-book (next PR), etc.)
- **Strategy pattern**: Different processing strategies can be selected based on library configuration

### 3. Improved File Path Handling

I've updated the file synchronization logic to use full paths instead of just filenames. This change:
- Prevents potential conflicts with duplicate filenames in different directories
- Provides more accurate file tracking
- Supports future features that may need path-based organization

This is mostly required for cases when I have additional files like `sources.zip`. So multiple folders could have this file, this is why I need dictionary by full path instead of just file name as it was before.

## Implementation Details

### New Components

1. **`BookFileProcessorRegistry`**: Manages the mapping between file extensions and their processors
2. **`LibraryFileProcessor` interface**: Defines the contract for library scanning strategies
3. **`LibraryFileProcessorRegistry`**: Selects appropriate library processor based on scan mode
4. **`FileAsBookProcessor`**: Extracted and refactored implementation of the existing file processing logic

### Updated Components

- **All file processors** (PDF, EPUB, CBX): Now declare their supported extensions
- **`LibraryProcessingService`**: Refactored to use the registry pattern
- **File synchronization logic**: Updated to use full paths

## Benefits

1. **Extensibility**: New file formats can be supported by simply adding a new processor
2. **Maintainability**: Clear separation of concerns between different processing modes
3. **Testability**: Isolated components are easier to unit test (comprehensive tests included)
4. **Performance**: Eliminates duplicate library scans during rescan operations

## Testing

- Added comprehensive unit tests for `FileAsBookProcessor` (364 lines of test coverage)
- All existing tests continue to pass
- Verified file processing works correctly for all supported formats
- Confirmed that library rescans no longer duplicate file scanning

## Future Considerations

This architecture sets the stage for:
- Folder-as-book processing mode
- Series detection and grouping
- Custom processing rules per library
- Plugin-based file processor extensions

## Discussion Points

I would appreciate feedback on:
- Whether the registry pattern aligns with the team's architectural preferences
- If there are additional scan modes we should consider in the design
- Any performance implications of the registry lookups (though EnumMap should be very efficient)
- Whether the full path usage might impact any existing integrations

## Related Issues

This work continues to build towards the requirements in #221 and establishes patterns that will be useful for other planned features.